### PR TITLE
Add Either support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ documentation = "https://docs.rs/pushgen"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+either = { version = "1.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod structs;
 pub mod test;
 
 pub use crate::generator_ext::GeneratorExt;
+pub use either::Either;
 pub use structs::from_fn::from_fn;
 
 /// Value-consumption result.
@@ -182,5 +183,20 @@ impl<'a, T> Generator for SliceGenerator<'a, T> {
             self.index += 1;
         }
         GeneratorResult::Complete
+    }
+}
+
+impl<L, R> Generator for Either<L, R>
+where
+    L: Generator,
+    R: Generator<Output = L::Output>,
+{
+    type Output = L::Output;
+
+    fn run(&mut self, output: impl FnMut(Self::Output) -> ValueResult) -> GeneratorResult {
+        match self {
+            Either::Left(left) => left.run(output),
+            Either::Right(right) => right.run(output),
+        }
     }
 }


### PR DESCRIPTION
This ensures users can abstract over two different types of
`Generator`s, as long as their `Output` is the same.

This mirrors `itertools::Either` which re-exports `either::Either`.  In
our case, we also have to add `impl Generator`.