### PR TITLE
Audit for missing `#[inline]`s

### DIFF
--- a/src/generator_ext.rs
+++ b/src/generator_ext.rs
@@ -30,6 +30,7 @@ pub trait GeneratorExt: Sealed + Generator {
     /// SliceGenerator::new(&data).chain(SliceGenerator::new(&data)).for_each(|x| output.push(*x));
     /// assert_eq!(output, [1, 2, 3, 1, 2, 3]);
     /// ```
+    #[inline]
     fn chain<Gen>(self, other: Gen) -> Chain<Self, Gen>
     where
         Self: Sized,
@@ -51,6 +52,7 @@ pub trait GeneratorExt: Sealed + Generator {
     /// assert_eq!(run_result, GeneratorResult::Complete);
     /// assert_eq!(output, [2,4]);
     /// ```
+    #[inline]
     fn filter<Pred>(self, predicate: Pred) -> Filter<Self, Pred>
     where
         Self: Sized,
@@ -115,6 +117,7 @@ pub trait GeneratorExt: Sealed + Generator {
     /// SliceGenerator::new(&data).map(|x| x.to_string()).for_each(|x| output.push(x));
     /// assert_eq!(output, ["1", "2", "3"]);
     /// ```
+    #[inline]
     fn map<Trans, Out>(self, transform_fn: Trans) -> Map<Self, Trans>
     where
         Self: Sized,
@@ -135,6 +138,7 @@ pub trait GeneratorExt: Sealed + Generator {
     /// skipped_generator.for_each(|x| output.push(*x));
     /// assert_eq!(output, [3,4]);
     /// ```
+    #[inline]
     fn skip(self, n: usize) -> Skip<Self>
     where
         Self: Sized,
@@ -152,6 +156,7 @@ pub trait GeneratorExt: Sealed + Generator {
     /// SliceGenerator::new(&data).take(2).for_each(|x| output.push(*x));
     /// assert_eq!(output, [1, 2]);
     /// ```
+    #[inline]
     fn take(self, n: usize) -> Take<Self>
     where
         Self: Sized,

--- a/src/into_gen.rs
+++ b/src/into_gen.rs
@@ -31,6 +31,7 @@ pub trait IntoGenerator {
 impl<G: crate::Generator> IntoGenerator for G {
     type Output = G::Output;
     type IntoGen = G;
+    #[inline]
     fn into_gen(self) -> Self::IntoGen {
         self
     }
@@ -39,6 +40,7 @@ impl<G: crate::Generator> IntoGenerator for G {
 impl<'a, T> IntoGenerator for &'a [T] {
     type Output = &'a T;
     type IntoGen = crate::SliceGenerator<'a, T>;
+    #[inline]
     fn into_gen(self) -> Self::IntoGen {
         crate::SliceGenerator::new(self)
     }
@@ -47,6 +49,7 @@ impl<'a, T> IntoGenerator for &'a [T] {
 impl<'a, T, const N: usize> IntoGenerator for &'a [T; N] {
     type Output = &'a T;
     type IntoGen = crate::SliceGenerator<'a, T>;
+    #[inline]
     fn into_gen(self) -> Self::IntoGen {
         crate::SliceGenerator::new(self)
     }
@@ -56,6 +59,7 @@ impl<'a, T, const N: usize> IntoGenerator for &'a [T; N] {
 impl<'a, T> IntoGenerator for &'a Vec<T> {
     type Output = &'a T;
     type IntoGen = crate::SliceGenerator<'a, T>;
+    #[inline]
     fn into_gen(self) -> Self::IntoGen {
         crate::SliceGenerator::new(self.as_slice())
     }
@@ -65,6 +69,7 @@ impl<'a, T> IntoGenerator for &'a Vec<T> {
 impl<T> IntoGenerator for Vec<T> {
     type Output = T;
     type IntoGen = crate::structs::FromIter<std::vec::IntoIter<T>>;
+    #[inline]
     fn into_gen(self) -> Self::IntoGen {
         crate::from_iter(self)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub enum ValueResult {
 }
 
 impl From<bool> for ValueResult {
+    #[inline]
     fn from(value: bool) -> Self {
         if !value {
             Self::Stop
@@ -85,6 +86,7 @@ pub enum GeneratorResult {
 }
 
 impl From<bool> for GeneratorResult {
+    #[inline]
     fn from(b: bool) -> Self {
         if !b {
             Self::Stopped
@@ -196,6 +198,7 @@ where
 {
     type Output = L::Output;
 
+    #[inline]
     fn run(&mut self, output: impl FnMut(Self::Output) -> ValueResult) -> GeneratorResult {
         match self {
             Either::Left(left) => left.run(output),

--- a/src/structs/flatten.rs
+++ b/src/structs/flatten.rs
@@ -15,6 +15,7 @@ where
     Src: Generator,
     Src::Output: IntoGenerator,
 {
+    #[inline]
     pub(crate) fn new(source: Src) -> Self {
         Self {
             source,

--- a/src/structs/from_fn.rs
+++ b/src/structs/from_fn.rs
@@ -33,6 +33,7 @@ use crate::{Generator, GeneratorResult, ValueResult};
 /// counter.for_each(|x| output.push(x));
 /// assert_eq!(output, [1, 2, 3, 4, 5]);
 /// ```
+#[inline]
 pub fn from_fn<T, F>(f: F) -> FromFn<F>
 where
     F: FnMut() -> Option<T>,
@@ -55,6 +56,7 @@ where
 {
     type Output = T;
 
+    #[inline]
     fn run(&mut self, mut output: impl FnMut(Self::Output) -> ValueResult) -> GeneratorResult {
         while let Some(v) = self.0() {
             if output(v) == ValueResult::Stop {

--- a/src/structs/iterator.rs
+++ b/src/structs/iterator.rs
@@ -13,6 +13,7 @@ impl<Src> IteratorAdaptor<Src>
 where
     Src: Generator,
 {
+    #[inline]
     pub fn new(source: Src) -> Self {
         Self { source }
     }


### PR DESCRIPTION
I realized in my previous PRs, I hadn't been inlining code that probably
should be, so I went back and audited all of the code for missing
`#[inline]`s.