### PR TITLE
Refactor Dedup::run: Avoid using Option::unwrap

### DIFF
--- a/src/structs/dedup.rs
+++ b/src/structs/dedup.rs
@@ -1,4 +1,4 @@
-use crate::{Generator, GeneratorResult, ValueResult};
+use crate::{Generator, GeneratorResult, ValueResult, structs::utility::unwrap_unchecked};
 
 /// Deduplication of duplicate consecutive values. See [`.dedup()`](crate::GeneratorExt::dedup) for details.
 pub struct Dedup<Src>
@@ -60,7 +60,7 @@ where
         // but if it was complete we assume no more values will be generated and
         // we need to output the last held value.
         if result == GeneratorResult::Complete
-            && output(self.next.take().unwrap()) == ValueResult::Stop
+            && output(unsafe { unwrap_unchecked(self.next.take()) }) == ValueResult::Stop
         {
             result = GeneratorResult::Stopped;
         }

--- a/src/structs/dedup.rs
+++ b/src/structs/dedup.rs
@@ -43,7 +43,7 @@ where
 
                 match self.next.take() {
                     Some(value) => value,
-                    None => return take_one_res
+                    None => return take_one_res,
                 }
             }
         };

--- a/src/structs/dedup.rs
+++ b/src/structs/dedup.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use crate::{Generator, GeneratorResult, ValueResult};
 
 /// Deduplication of duplicate consecutive values. See [`.dedup()`](crate::GeneratorExt::dedup) for details.
@@ -52,7 +53,7 @@ where
                 prev = x;
                 ValueResult::MoreValues
             } else {
-                output(std::mem::replace(&mut prev, x))
+                output(mem::replace(&mut prev, x))
             }
         });
 

--- a/src/structs/dedup.rs
+++ b/src/structs/dedup.rs
@@ -1,5 +1,5 @@
-use core::mem;
 use crate::{Generator, GeneratorResult, ValueResult};
+use core::mem;
 
 /// Deduplication of duplicate consecutive values. See [`.dedup()`](crate::GeneratorExt::dedup) for details.
 pub struct Dedup<Src>
@@ -64,7 +64,7 @@ where
                 result = GeneratorResult::Stopped;
             }
         } else {
-            // If the source generator was stopped we might have more values 
+            // If the source generator was stopped we might have more values
             // coming later runs,
             self.next = Some(prev);
         }

--- a/src/structs/dedup.rs
+++ b/src/structs/dedup.rs
@@ -1,4 +1,4 @@
-use std::mem;
+use core::mem;
 use crate::{Generator, GeneratorResult, ValueResult};
 
 /// Deduplication of duplicate consecutive values. See [`.dedup()`](crate::GeneratorExt::dedup) for details.

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(feature = "std")]
 pub(crate) mod boxed;
 
+mod utility;
 mod chain;
 mod cloned;
 mod dedup;

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -3,7 +3,6 @@
 #[cfg(feature = "std")]
 pub(crate) mod boxed;
 
-mod utility;
 mod chain;
 mod cloned;
 mod dedup;
@@ -17,6 +16,7 @@ mod map;
 mod option;
 mod skip;
 mod take;
+mod utility;
 mod zip;
 
 pub use chain::Chain;

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -1,11 +1,11 @@
-// unlike unreachable!() which will panic on reaching, unreachable_unchecked
-// has no effect on the generated code and it will be UB if it is actually reached.
-use std::hint::unreachable_unchecked;
+use std::hint;
 
 #[allow(dead_code)]
 pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {
     match option {
         Some(val) => val,
-        None => unreachable_unchecked(),
+        // unlike unreachable!() which will panic on reaching, unreachable_unchecked
+        // has no effect on the generated code and it will be UB if it is actually reached.
+        None => hint::unreachable_unchecked(),
     }
 }

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -1,0 +1,10 @@
+// unlike unreachable!() which will panic on reaching, unreachable_unchecked
+// has no effect on the generated code and it will be UB if it is actually reached.
+use std::hint::unreachable_unchecked;
+
+pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {
+    match option {
+        Some(val) => val,
+        None => unreachable_unchecked()
+    }
+}

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -1,4 +1,4 @@
-use std::hint;
+use core::hint;
 
 #[allow(dead_code)]
 pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -2,6 +2,7 @@
 // has no effect on the generated code and it will be UB if it is actually reached.
 use std::hint::unreachable_unchecked;
 
+#[allow(dead_code)]
 pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {
     match option {
         Some(val) => val,

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -1,6 +1,7 @@
 use core::hint;
 
 #[allow(dead_code)]
+#[inline(always)]
 pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {
     match option {
         Some(val) => val,

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -5,6 +5,6 @@ use std::hint::unreachable_unchecked;
 pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {
     match option {
         Some(val) => val,
-        None => unreachable_unchecked()
+        None => unreachable_unchecked(),
     }
 }


### PR DESCRIPTION
 - Add new `unsafe fn struct::utility::unwrap_unchecked<T>(Option<T>)`
 - Replace the use of unwrap in the initialization stage with `match` and remove the use of it in the loop,
 - Use unwrap_unchecked to handle last element in Dedup::run to avoid using Option::unwrap which might have additional overhead due to use of panic.