### PR TITLE
 Comment on why prev = x in Dedup::run cannot be removed

### DIFF
--- a/src/structs/dedup.rs
+++ b/src/structs/dedup.rs
@@ -50,6 +50,8 @@ where
 
         let mut result = self.source.run(|x| {
             if x == prev {
+                // Removing this line causes the regression of the performance of
+                // bench pushgen_dedup_flatten_filter_map
                 prev = x;
                 ValueResult::MoreValues
             } else {


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>