### PR TITLE
 Refactor IteratorAdaptor::fold: Replace use of unwrap with InplaceUpdatable

### DIFF
--- a/src/structs/iterator.rs
+++ b/src/structs/iterator.rs
@@ -1,4 +1,4 @@
-use crate::{Generator, ValueResult};
+use crate::{structs::utility::InplaceUpdatable, Generator, ValueResult};
 use core::option::Option::Some;
 
 /// Adapt a generator into an iterator. See [`.iter()`](crate::GeneratorExt::iter) for more info.
@@ -41,12 +41,12 @@ where
         Self: Sized,
         F: FnMut(B, Self::Item) -> B,
     {
-        let mut result = Some(init);
+        let mut result = InplaceUpdatable::new(init);
         self.source.run(|x| {
-            result = Some(f(result.take().unwrap(), x));
+            result.update(|val| f(val, x));
             ValueResult::MoreValues
         });
-        result.unwrap()
+        result.get_inner()
     }
 }
 

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -34,6 +34,7 @@ impl<T> InplaceUpdatable<T> {
         self.inner = Some(new_val);
     }
 
+    #[inline(always)]
     pub fn get_inner(self) -> T {
         unsafe { unwrap_unchecked(self.inner) }
     }

--- a/src/structs/utility.rs
+++ b/src/structs/utility.rs
@@ -1,6 +1,5 @@
 use core::hint;
 
-#[allow(dead_code)]
 #[inline(always)]
 pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {
     match option {
@@ -8,5 +7,34 @@ pub unsafe fn unwrap_unchecked<T>(option: Option<T>) -> T {
         // unlike unreachable!() which will panic on reaching, unreachable_unchecked
         // has no effect on the generated code and it will be UB if it is actually reached.
         None => hint::unreachable_unchecked(),
+    }
+}
+
+/// Implements this functionality as a struct instead of a function taking Option<T>
+/// to make sure that we won't accidentally treats a None as a Some and avoids the
+/// unsafe fn altogether.
+pub struct InplaceUpdatable<T> {
+    // Using Option here is necessary for integrity during unwind,
+    // which is the only moment where inner is set to None.
+    //
+    // In every other cases, it is set to `Some(value)`.
+    inner: Option<T>,
+}
+impl<T> InplaceUpdatable<T> {
+    #[inline(always)]
+    pub const fn new(value: T) -> InplaceUpdatable<T> {
+        InplaceUpdatable { inner: Some(value) }
+    }
+
+    #[inline(always)]
+    pub fn update(&mut self, updater: impl FnOnce(T) -> T) {
+        // take self.inner to ensure nothing will be dropped here during unwind,
+        // if updater ever panic
+        let new_val = updater(unsafe { unwrap_unchecked(self.inner.take()) });
+        self.inner = Some(new_val);
+    }
+
+    pub fn get_inner(self) -> T {
+        unsafe { unwrap_unchecked(self.inner) }
     }
 }


### PR DESCRIPTION
Also add new struct utility::InplaceUpdatable:

Implements associated methods for safely replacing a `&mut` value without
any unsafe fn and doesn't pose any UB under panic unwind.